### PR TITLE
Synchronize DB schema with production

### DIFF
--- a/config/db/0000_initialize.sql
+++ b/config/db/0000_initialize.sql
@@ -1,6 +1,18 @@
+START TRANSACTION;
+
 CREATE TABLE `dice_emails` (
   `registered_email` varchar(255) NOT NULL,
   UNIQUE KEY `registered_email` (`registered_email`)
+) DEFAULT CHARSET=latin1;
+
+CREATE TABLE `dice_table` (
+  `request_ID` int(11) NOT NULL AUTO_INCREMENT,
+  `UUID` varchar(36) NOT NULL,
+  `dice` varchar(256) NOT NULL,
+  `subject` varchar(70) NOT NULL,
+  `time_stamp` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`request_ID`),
+  KEY `UUID` (`UUID`)
 ) DEFAULT CHARSET=latin1;
 
 CREATE TABLE `pending_validations` (
@@ -10,3 +22,5 @@ CREATE TABLE `pending_validations` (
   `IP` int(10) unsigned NOT NULL,
   UNIQUE KEY `email` (`email`)
 ) DEFAULT CHARSET=latin1;
+
+COMMIT;


### PR DESCRIPTION
I know the `dice_table` table is not used, but it exists in production.  In order to properly test its future removal via a migration script, it needs to exist in the initial schema.