### PR TITLE
Remove .well-known folder

### DIFF
--- a/dice/.well-known/.gitignore
+++ b/dice/.well-known/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This folder is created by the server per RFC 5785.  It should not be configuration managed.