### PR TITLE
Remove transaction for DDL statements

### DIFF
--- a/config/db/0000_initialize.sql
+++ b/config/db/0000_initialize.sql
@@ -1,5 +1,3 @@
-START TRANSACTION;
-
 CREATE TABLE `dice_emails` (
   `registered_email` varchar(255) NOT NULL,
   UNIQUE KEY `registered_email` (`registered_email`)
@@ -22,5 +20,3 @@ CREATE TABLE `pending_validations` (
   `IP` int(10) unsigned NOT NULL,
   UNIQUE KEY `email` (`email`)
 ) DEFAULT CHARSET=latin1;
-
-COMMIT;


### PR DESCRIPTION
MySQL DDL statements implicitly commit because they cannot be rolled back upon failure.  Therefore, while the presence of a transaction block does not raise an error when this script is run, it is effectively useless.