### PR TITLE
Normalize indentation

### DIFF
--- a/build/docker/marti-dev/web-files/root/etc/nginx/conf.d/default.conf
+++ b/build/docker/marti-dev/web-files/root/etc/nginx/conf.d/default.conf
@@ -12,7 +12,7 @@ server {
     }
 
     location ~ \.(key|dat)$ {
-      deny all;
+        deny all;
     }
 
     location ~ \.php$ {


### PR DESCRIPTION
This is a whitespace-only change to ensure the indentation in the Nginx Docker container's configuration file is consistent.  We apparently use four spaces per indentation level.