### PR TITLE
Add instructions for deploying application

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -12,3 +12,23 @@ This folder contains scripts for performing various tasks related to the MARTI d
     ```bash
     $ ./bin/migrate_db ./config/db 0 marti_staging marti_dice
     ```
+
+## Deploy application
+
+In the following steps, `<dir>` refers to the deployment directory.  This will be `dice` for the production application and `dice-staging` for the staging application.
+
+1. Login to `dice.tripleawarclub.org`.
+1. Create the deployment directory if necessary.
+    1. Create the directory:
+        ```bash
+        $ sudo mkdir /usr/share/nginx/html/tripleawarclub.org/public_html/<dir>/
+        ```
+    1. Change ownership:
+        ```bash
+        $ sudo chown www-data:www-data /usr/share/nginx/html/tripleawarclub.org/public_html/<dir>/
+        ```
+1. Change to the directory where you have cloned the `triplea-game/dice-server` repo.
+1. Deploy the application:
+    ```bash
+    $ sudo -u www-data ./bin/deploy ./src/ /usr/share/nginx/html/tripleawarclub.org/public_html/<dir>/
+    ```

--- a/bin/deploy
+++ b/bin/deploy
@@ -25,14 +25,3 @@ cp -R "$1/." "$2"
 # Delete any .gitignore files in the destination folder that may have been
 # copied in the previous step.
 find "$2" -type f -name '.gitignore' -delete
-
-# Change ownership of the new files copied to the destination folder so they
-# are accessible by the web server.  We once again ignore any files/folders
-# generated at runtime to preserve their original permissions.
-find \
-  "$2" \
-  -mindepth 1 \
-  -not -name '*.dat' \
-  -not -name 'keys' \
-  -not -name '.well-known' \
-  -exec chown www-data:www-data {} +


### PR DESCRIPTION
The last step of the _bin/deploy_ script is no longer necessary given that the deployment instructions document the destination folder should have the correct ownership information.