### PR TITLE
Move staging Nginx logs

### DIFF
--- a/config/nginx/dice-staging.tripleawarclub.org
+++ b/config/nginx/dice-staging.tripleawarclub.org
@@ -4,8 +4,8 @@ server {
   server_name dice-staging.tripleawarclub.org;
   root /usr/share/nginx/html/dice-staging.tripleawarclub.org/public_html;
 
-  access_log /usr/share/nginx/html/dice-staging.tripleawarclub.org/logs/access.log;
-  error_log /usr/share/nginx/html/dice-staging.tripleawarclub.org/logs/error.log;
+  access_log /var/log/nginx/dice-staging.tripleawarclub.org-access.log;
+  error_log /var/log/nginx/dice-staging.tripleawarclub.org-error.log;
 
   index index.php;
 


### PR DESCRIPTION
Per triplea-game/tripleawarclub.org#14.

_/var/log/nginx_ is the canonical location for Nginx logs on Ubuntu.  Logs in this folder will be automatically rotated.
