### PR TITLE
Update instructions for deploying staging application

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -21,15 +21,13 @@ This folder contains scripts for performing various tasks related to the MARTI d
 
 ### Staging
 
-In the following steps, `<dir>` refers to the deployment directory.  This will be `dice` for the production application and `dice-staging` for the staging application.
-
 1. Login to `dice-staging.tripleawarclub.org`.
 1. Create the deployment directory if necessary.
     ```bash
     $ sudo mkdir /usr/share/nginx/html/dice-staging.tripleawarclub.org
     $ sudo chmod 2755 /usr/share/nginx/html/dice-staging.tripleawarclub.org/
     $ sudo chown www-data:www-data /usr/share/nginx/html/dice-staging.tripleawarclub.org/
-    $ sudo -u www-data mkdir /usr/share/nginx/html/dice-staging.tripleawarclub.org/public_html /usr/share/nginx/html/dice-staging.tripleawarclub.org/logs
+    $ sudo -u www-data mkdir /usr/share/nginx/html/dice-staging.tripleawarclub.org/public_html
     ```
 1. Change to the directory where you have cloned the `triplea-game/dice-server` repo.
 1. Deploy the application:


### PR DESCRIPTION
* The _logs/_ folder is no longer necessary as logs will be written to the canonical _/var/log/nginx/_ folder.
* Remove text that is no longer applicable.