### PR TITLE
Add Nginx configuration for production subdomain

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -17,7 +17,22 @@ This folder contains scripts for performing various tasks related to the MARTI d
 
 ### Production
 
-**TODO**
+1. Login to `dice.tripleawarclub.org`.
+1. Create the deployment directory if necessary.
+    ```bash
+    $ sudo mkdir /usr/share/nginx/html/dice.tripleawarclub.org
+    $ sudo chmod 2755 /usr/share/nginx/html/dice.tripleawarclub.org/
+    $ sudo chown www-data:www-data /usr/share/nginx/html/dice.tripleawarclub.org/
+    $ sudo -u www-data mkdir /usr/share/nginx/html/dice.tripleawarclub.org/public_html
+    ```
+1. Change to the directory where you have cloned the `triplea-game/dice-server` repo.
+1. Deploy the application:
+    ```bash
+    $ sudo -u www-data ./bin/deploy ./src/ /usr/share/nginx/html/dice.tripleawarclub.org/public_html/
+    ```
+1. Smoke test the application as needed.
+    * Load home page at https://dice.tripleawarclub.org/ .
+    * Use the TripleA client to send a test email.
 
 ### Staging
 

--- a/config/nginx/README.md
+++ b/config/nginx/README.md
@@ -4,7 +4,29 @@ This folder contains the Nginx configurations used by the MARTI production and s
 
 ### Production
 
-**TODO**
+The following process is used to update the Nginx configuration for the `dice.tripleawarclub.org` subdomain:
+
+1. Submit a PR to this repo with the proposed change to _config/nginx/dice.tripleawarclub.org_.
+1. Review and merge the PR.
+1. Login to `dice.tripleawarclub.org`.
+1. Change to the directory where you have cloned the `triplea-game/dice-server` repo and checkout the appropriate tag/branch.
+1. Review the changes to be applied to ensure the deployed configuration has not been modified outside of this process.
+    ```bash
+    $ git diff /etc/nginx/sites-available/dice.tripleawarclub.org ./config/nginx/dice.tripleawarclub.org
+    ```
+1. Copy the new configuration.
+    ```bash
+    $ sudo cp ./config/nginx/dice.tripleawarclub.org /etc/nginx/sites-available/
+    ```
+1. Enable the configuration if needed.
+    ```bash
+    $ sudo ln -s /etc/nginx/sites-available/dice.tripleawarclub.org /etc/nginx/sites-enabled/dice.tripleawarclub.org
+    ```
+1. Reload the Nginx configuration.
+    ```bash
+    $ sudo systemctl reload nginx
+    ```
+1. Smoke test the new configuration as needed.
 
 ### Staging
 

--- a/config/nginx/dice.tripleawarclub.org
+++ b/config/nginx/dice.tripleawarclub.org
@@ -1,0 +1,40 @@
+server {
+  listen 80;
+  listen [::]:80;
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name dice.tripleawarclub.org;
+  root /usr/share/nginx/html/dice.tripleawarclub.org/public_html;
+
+  ssl_certificate /etc/letsencrypt/live/tripleawarclub.org/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/tripleawarclub.org/privkey.pem;
+
+  # Turn on OCSP stapling as recommended at
+  # https://community.letsencrypt.org/t/integration-guide/13123
+  # requires nginx version >= 1.3.7
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security "max-age=31536000";
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/dhparam/dhparams.pem;
+
+  access_log /var/log/nginx/dice.tripleawarclub.org-access.log;
+  error_log /var/log/nginx/dice.tripleawarclub.org-error.log;
+
+  index index.html index.htm index.php;
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+
+  location ~ \.php$ {
+    include snippets/fastcgi-php.conf;
+    include marti_prod_fastcgi_params;
+    fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+  }
+
+  location ~ \.(key|dat)$ {
+    deny all;
+  }
+}


### PR DESCRIPTION
In support of triplea-game/tripleawarclub.org#16.

The new Nginx configuration is essentially a copy of the existing configuration from the _tripleawarclub.org_ configuration with the following changes:

* Root location changed
* Log locations changed to _/var/log/nginx/_

There will be a peer PR in the triplea-game/tripleawarclub.org repo that removes the MARTI production configuration from the _tripleawarclub.org_ configuration.