### PR TITLE
Fix IPv6 registration error

### DIFF
--- a/src/register.php
+++ b/src/register.php
@@ -33,7 +33,9 @@ else {
 	// collecting information for validation
 	$time = time(); // in unix format
 	$validation = md5($email . $time . rand());
-	$IP = ip2long($_SERVER['REMOTE_ADDR']);
+	// ignore IP for now due to ip2long() not being able to handle IPv6 addresses
+	// TODO: remove this column from the database
+	$IP = 0;
 
 	$sql = "SELECT email FROM pending_validations WHERE email=?";
 	$rows = array();


### PR DESCRIPTION
Fixes triplea-game/triplea#2603.

The `ip2long()` function cannot parse an IPv6 address.  Thus, when a user registers using a public IPv6 address, the IP variable contains the value `FALSE` instead of an integer representing the IP address.  This prevents the record from being inserted into the `pending_validations` table.  However, due to improper error handling, the user still receives an email asking them to confirm their email address.  Any attempt to verify the email address fails due to no corresponding record being present in the `pending_validations` table.

It was observed that we don't actually use the the IP address recorded in the `pending_validations` table.  Therefore, the temporary fix employed in this commit is to simply set the IP address to zero for all registrations.  A future change will remove this column from the database entirely.