### PR TITLE
Define variable before use

### DIFF
--- a/src/dice.class.php
+++ b/src/dice.class.php
@@ -126,6 +126,7 @@ class dice {
 
 	function keygen() {
 		$tempstring = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+		$pass = "";
 		for($length = 1; $length < 24; $length++) {
 			$temp = str_shuffle($tempstring);
 			$char = mt_rand(0, strlen($temp));


### PR DESCRIPTION
This PR simply fixes an undefined variable warning I've observed in the logs:

```
NOTICE: PHP message: PHP Notice:  Undefined variable: pass in /usr/share/nginx/html/dice/dice.class.php on line 132
```