### PR TITLE
Fix too high indexes

### DIFF
--- a/src/dice.class.php
+++ b/src/dice.class.php
@@ -129,7 +129,7 @@ class dice {
 		$pass = "";
 		for($length = 1; $length < 24; $length++) {
 			$temp = str_shuffle($tempstring);
-			$char = mt_rand(0, strlen($temp));
+			$char = mt_rand(0, strlen($temp) - 1);
 			$pass .= $temp[$char];
 		}
 		return $pass;

--- a/src/dice.class.php
+++ b/src/dice.class.php
@@ -129,7 +129,7 @@ class dice {
 		$pass = "";
 		for($length = 1; $length < 24; $length++) {
 			$temp = str_shuffle($tempstring);
-			$char = mt_rand(0, strlen($temp) - 1);
+			$char = random_int(0, strlen($temp) - 1);
 			$pass .= $temp[$char];
 		}
 		return $pass;


### PR DESCRIPTION
I got the following warning (unrelated to this PR) when invoking MARTI.php for the first time during testing of the last PR:
`<b>Notice</b>:  Uninitialized string offset: 124 in <b>/usr/share/nginx/html/dice/dice.class.php</b> on line <b>125</b><br />`
Seems like mt_rand is inclusive, so in a 1/124 chance on key creation this error can happen ^^