### PR TITLE
Enhance keygen

### DIFF
--- a/src/dice.class.php
+++ b/src/dice.class.php
@@ -115,22 +115,13 @@ class dice {
 
 		if ($shouldWriteKey) {
 			$file = fopen("key.dat", "w");
-			$enc['key'] = $this->keygen();
+			$enc['key'] = base64_encode(random_bytes(24));
 			$enc['date'] = $this->getDate();
 			$output = serialize($enc);
 			fputs($file, $output);
 			fclose($file);
 			chmod("key.dat", 0600);
 		}
-	}
-
-	function keygen() {
-		$charset = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-		$pass = "";
-		for($length = 0; $length < 24; $length++) {
-			$pass .= $charset[random_int(0, strlen($charset) - 1)];
-		}
-		return $pass;
 	}
 
 	function encrypt_data($input) {

--- a/src/dice.class.php
+++ b/src/dice.class.php
@@ -125,12 +125,10 @@ class dice {
 	}
 
 	function keygen() {
-		$tempstring = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+		$charset = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 		$pass = "";
-		for($length = 1; $length < 24; $length++) {
-			$temp = str_shuffle($tempstring);
-			$char = random_int(0, strlen($temp) - 1);
-			$pass .= $temp[$char];
+		for($length = 0; $length < 24; $length++) {
+			$pass .= $charset[random_int(0, strlen($charset) - 1)];
 		}
 		return $pass;
 	}


### PR DESCRIPTION
This simplifies the keygen method.
There are some minor functional changes such as an increased byte-length of 24 instead of 23 bytes, and +, / and = being used as additional characters due to the nature of base64.
I verified at least the `+` sign works, by regenerating the key so often it finally contained such a special char. The other characters should really work as well, as long as `mcrypt_generic_init` supports them (I found no indicator it doesn't)