### PR TITLE
Ignore all whitespace delimiters in email address lists

### DIFF
--- a/src/MARTI.php
+++ b/src/MARTI.php
@@ -26,8 +26,8 @@ ini_set('display_errors', '1');
 			exit("fatal error: no second email found. Please enter an email address into the CC-field!");
 		}
 		//format multiple emails in one line
-		$emails1 = explode(" ", $email1);
-		$emails2 = explode(" ", $email2);
+		$emails1 = preg_split("/\s+/", $email1, -1, PREG_SPLIT_NO_EMPTY);
+		$emails2 = preg_split("/\s+/", $email2, -1, PREG_SPLIT_NO_EMPTY);
 
 		$output['emails'] = array_merge($emails1, $emails2);
 		// get exact server time


### PR DESCRIPTION
Fixes #33.

These fields are space-delimited lists of email addresses.  The `explode()` function only ignores a single space delimiter between each address.  If there are any leading or trailing spaces, or more than one space between each address, the resulting list will contain an empty address.  As an empty address will never be registered, MARTI will refuse to process the dice roll request.

The fix is to split the string regardless of the number of whitespace delimiters before, between, and after each address.

#### Testing

I tested the following scenarios:

* Multiple space characters before To address.
* Multiple space characters after To address.
* Multiple space characters between two To addresses.
* Multiple space characters before Cc address.
* Multiple space characters after Cc address.
* Multiple space characters between two Cc addresses.