### PR TITLE
Replace trigger_error() with exit()

### DIFF
--- a/src/register.php
+++ b/src/register.php
@@ -37,7 +37,7 @@
 			$sql = "REPLACE INTO pending_validations (email, validation_key, IP) VALUES (?, ?, 0)";
 			$sth = $dice->dbconn->prepare($sql);
 			$sth->bind_param('ss', $email, $validation);
-			$sth->execute() or trigger_error($dice->dbconn->error);
+			$sth->execute() or exit($dice->dbconn->error);
 			$sth->close();
 
 			// sending email

--- a/src/unsubscribe.php
+++ b/src/unsubscribe.php
@@ -29,7 +29,7 @@
 
 			$sth = $dice->dbconn->prepare("DELETE FROM dice_emails WHERE registered_email=?");
 			$sth->bind_param('s',$email);
-			$sth->execute() or trigger_error($dice->dbconn->error);
+			$sth->execute() or exit($dice->dbconn->error);
 
 			echo "Your email was successfully removed. You will no longer receive dice emails.";
 		}

--- a/src/validate.php
+++ b/src/validate.php
@@ -19,7 +19,7 @@
 
 		$sth = $dice->dbconn->prepare("SELECT COUNT(*) FROM pending_validations WHERE email=? AND validation_key=?");
 		$sth->bind_param('ss', $email, $validation);
-		$sth->execute() or trigger_error($dice->dbconn->error);
+		$sth->execute() or exit($dice->dbconn->error);
 		$sth->bind_result($entry_count);
 		$sth->fetch();
 		if ($entry_count === 0) {
@@ -29,12 +29,12 @@
 
 		$sth = $dice->dbconn->prepare("INSERT INTO dice_emails (registered_email) VALUES (?)");
 		$sth->bind_param('s', $email);
-		$sth->execute() or trigger_error($dice->dbconn->error);
+		$sth->execute() or exit($dice->dbconn->error);
 		$sth->close();
 
 		$sth = $dice->dbconn->prepare("DELETE FROM pending_validations WHERE email=?");
 		$sth->bind_param('s', $email);
-		$sth->execute() or trigger_error($dice->dbconn->error);
+		$sth->execute() or exit($dice->dbconn->error);
 		$sth->close();
 
 		echo "Registration was successful. You can now use the MARTI dice server.";


### PR DESCRIPTION
`trigger_error()` does not exit the script and continues execution on the next line.  This can lead to incorrect behavior.

For example, if the `REPLACE` SQL statement in _register.php_ fails for some reason, the script will still send the user a registration email.  Because no record exists in the `pending_validations` table, all attempts the user makes to validate their email will fail.  This was the exact scenario we had when users would attempt to register using an IPv6 address.