### PR TITLE
Improve Docker development environment

### DIFF
--- a/build/docker/marti-dev/README.md
+++ b/build/docker/marti-dev/README.md
@@ -25,3 +25,25 @@ where the `smtp_*` variables are specific to your ISP or email provider.  **The 
 Note that the `up` command will also build the images if this is the first run.
 
 Once the container is started, navigate to `http://localhost:4000` from the host to bring up the MARTI home page.
+
+### Development
+
+If you wish to edit the MARTI source code live while the containers are running, uncomment the commented-out lines for the `src-volume` volume in _docker-compose.yml_.  You must update the `device` driver option to be the absolute path to the _src/_ folder in your MARTI Git repository.
+
+#### Linux hosts running SELinux or AppArmor
+
+When binding your host development folder to the `src-volume` volume, the ownership and permissions of the _src/_ folder will be changed to allow access by the containers.  To restore the original ownership, run the following command from the root of your Git repository:
+
+```
+$ sudo chown -R <user>:<group> src
+```
+
+where _<user>_ is your username and _<group>_ is your primary group.
+
+To restore the original context labels, run the following command from the root of your Git repository:
+
+```
+$ sudo chcon -R --reference=README.md src
+```
+
+This will restore the context labels for all files under and including the _src/_ folder to their original values (any sibling entry can be used as the reference; _README.md_ was picked arbitrarily).

--- a/build/docker/marti-dev/app.df
+++ b/build/docker/marti-dev/app.df
@@ -14,13 +14,13 @@ RUN apt-get -y update \
   && docker-php-ext-install mcrypt mysqli
 
 COPY ["./build/docker/marti-dev/app-files/root", "/"]
-COPY ["./src", "/usr/share/nginx/html/dice"]
 
 RUN groupadd ssmtp \
   && chown :ssmtp /etc/ssmtp/ssmtp.conf \
   && chown :ssmtp /usr/sbin/ssmtp \
   && chmod 640 /etc/ssmtp/ssmtp.conf \
   && chmod g+s /usr/sbin/ssmtp \
-  && chown -R www-data:www-data /usr/share/nginx/html
+  && mkdir -p /usr/share/nginx/html/dice \
+  && chown www-data:www-data /usr/share/nginx/html/dice
 
 ENTRYPOINT ["marti-app-entrypoint"]

--- a/build/docker/marti-dev/docker-compose.yml
+++ b/build/docker/marti-dev/docker-compose.yml
@@ -1,15 +1,6 @@
 version: '3.1'
 
 services:
-  web:
-    build:
-      context: ../../..
-      dockerfile: build/docker/marti-dev/web.df
-    ports:
-      - '4000:80'
-    depends_on:
-      - app
-
   app:
     build:
       context: ../../..
@@ -21,8 +12,31 @@ services:
       - MARTI_SMTP_PORT=${MARTI_SMTP_PORT}
       - MARTI_SMTP_USERNAME=${MARTI_SMTP_USERNAME}
       - MARTI_SMTP_PASSWORD=${MARTI_SMTP_PASSWORD}
+    volumes:
+      - src-volume:/usr/share/nginx/html/dice
 
   sql:
     build:
       context: ../../..
       dockerfile: build/docker/marti-dev/sql.df
+
+  src:
+    build:
+      context: ../../..
+      dockerfile: build/docker/marti-dev/src.df
+    volumes:
+      - src-volume:/marti-src
+
+  web:
+    build:
+      context: ../../..
+      dockerfile: build/docker/marti-dev/web.df
+    depends_on:
+      - app
+    ports:
+      - '4000:80'
+    volumes:
+      - src-volume:/usr/share/nginx/html/dice
+
+volumes:
+  src-volume:

--- a/build/docker/marti-dev/docker-compose.yml
+++ b/build/docker/marti-dev/docker-compose.yml
@@ -40,3 +40,9 @@ services:
 
 volumes:
   src-volume:
+    # Uncomment the following lines and update the device path to bind your host's src folder to the volume so you can
+    # edit the source code live without having to rebuild the src container.
+    #driver_opts:
+    #  type: none
+    #  device: /home/user/path/to/triplea-game/dice-server/src
+    #  o: bind

--- a/build/docker/marti-dev/src.df
+++ b/build/docker/marti-dev/src.df
@@ -1,0 +1,8 @@
+#
+# Dockerfile for building the MARTI source container.
+#
+
+FROM busybox:1.28.0
+MAINTAINER "tripleabuilderbot@gmail.com"
+
+COPY ["./src", "/marti-src"]

--- a/build/docker/marti-dev/web.df
+++ b/build/docker/marti-dev/web.df
@@ -17,4 +17,3 @@ RUN printf "fastcgi_param MARTI_DB_HOST $MARTI_DB_HOST;\n" >> /etc/nginx/marti_f
   && printf "fastcgi_param MARTI_DB_NAME $MARTI_DB_NAME;" >> /etc/nginx/marti_fastcgi_params
 
 COPY ["./build/docker/marti-dev/web-files/root", "/"]
-COPY ["./src", "/usr/share/nginx/html/dice"]


### PR DESCRIPTION
* Add the `src` data container so the MARTI source code does not need to be duplicated in the `app` and `web` containers.  This also speeds up builds if changing the source code.
* Add instructions for binding a host folder to the `src-volume` volume so changes can be made to the source code on the host and reflected live in the containers without having to rebuild the `src` container.