### PR TITLE
Migrate admin notes from triplea-game/triplea

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ The MARTI dice server.
 * [Setup and deployment](https://github.com/triplea-game/dice-server/tree/master/bin)
 * [Web server configuration](https://github.com/triplea-game/dice-server/tree/master/config/nginx)
 * [Docker development environment](https://github.com/triplea-game/dice-server/tree/master/build/docker/marti-dev)
+
+## Starting and Stopping
+
+```
+sudo service nginx restart
+```


### PR DESCRIPTION
Migrating cleaned up content (https://github.com/triplea-game/triplea/pull/3659) from: https://github.com/triplea-game/triplea/edit/master/docs/admin/README.md, to this location.
