### PR TITLE
Update https conf

### DIFF
--- a/config/nginx/dice-staging.tripleawarclub.org
+++ b/config/nginx/dice-staging.tripleawarclub.org
@@ -19,6 +19,7 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
   add_header Strict-Transport-Security "max-age=31536000";
+  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/dhparam/dhparams.pem;

--- a/config/nginx/dice-staging.tripleawarclub.org
+++ b/config/nginx/dice-staging.tripleawarclub.org
@@ -1,3 +1,7 @@
+# Session caching for improved performance
+
+ssl_session_cache shared:ssl_session_cache:10m;
+
 server {
   listen 80;
   listen [::]:80;

--- a/config/nginx/dice.tripleawarclub.org
+++ b/config/nginx/dice.tripleawarclub.org
@@ -19,6 +19,7 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
   add_header Strict-Transport-Security "max-age=31536000";
+  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/dhparam/dhparams.pem;

--- a/config/nginx/dice.tripleawarclub.org
+++ b/config/nginx/dice.tripleawarclub.org
@@ -1,3 +1,7 @@
+# Session caching for improved performance
+
+ssl_session_cache shared:ssl_session_cache:10m;
+
 server {
   listen 80;
   listen [::]:80;


### PR DESCRIPTION
The PR increases the HTTPS security by dropping TLSv1.0 support and caches the ssl session for more theoretical performance.
(I don't think having the same setting applied multiple times should cause a problem, see my diff comment for more information)
