### PR TITLE
Add config files for newly created subdomain

### DIFF
--- a/config/nginx/dice-staging.marti.triplea-game.org
+++ b/config/nginx/dice-staging.marti.triplea-game.org
@@ -1,7 +1,3 @@
-# Session caching for improved performance
-
-ssl_session_cache shared:ssl_session_cache:10m;
-
 server {
   listen 80;
   listen [::]:80;
@@ -24,7 +20,6 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
   add_header Strict-Transport-Security "max-age=31536000";
-  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/dhparam/dhparams.pem;

--- a/config/nginx/dice-staging.marti.triplea-game.org
+++ b/config/nginx/dice-staging.marti.triplea-game.org
@@ -1,0 +1,46 @@
+# Session caching for improved performance
+
+ssl_session_cache shared:ssl_session_cache:10m;
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name dice-staging.marti.triplea-game.org;
+  return 301 https://dice-staging.marti.triplea-game.org$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name dice-staging.marti.triplea-game.org;
+  root /usr/share/nginx/html/dice-staging.tripleawarclub.org/public_html;
+
+  ssl_certificate /etc/letsencrypt/live/dice-staging.marti.triplea-game.org/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dice-staging.marti.triplea-game.org/privkey.pem;
+
+  # Turn on OCSP stapling as recommended at
+  # https://community.letsencrypt.org/t/integration-guide/13123
+  # requires nginx version >= 1.3.7
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security "max-age=31536000";
+  ssl_protocols TLSv1.1 TLSv1.2;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/dhparam/dhparams.pem;
+
+  access_log /var/log/nginx/dice-staging.tripleawarclub.org-access.log;
+  error_log /var/log/nginx/dice-staging.tripleawarclub.org-error.log;
+
+  index register.php;
+
+  location ~ \.php$ {
+    include snippets/fastcgi-php.conf;
+    include marti_staging_fastcgi_params;
+    fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+  }
+
+  location ~ \.(key|dat)$ {
+    deny all;
+  }
+}

--- a/config/nginx/dice.marti.triplea-game.org
+++ b/config/nginx/dice.marti.triplea-game.org
@@ -1,0 +1,46 @@
+# Session caching for improved performance
+
+ssl_session_cache shared:ssl_session_cache:10m;
+
+server {
+  listen 80;
+  listen [::]:80;
+  server_name dice.marti.triplea-game.org;
+  return 301 https://dice.marti.triplea-game.org$request_uri;
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name dice.marti.triplea-game.org;
+  root /usr/share/nginx/html/dice.tripleawarclub.org/public_html;
+
+  ssl_certificate /etc/letsencrypt/live/dice.marti.triplea-game.org/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/dice.marti.triplea-game.org/privkey.pem;
+
+  # Turn on OCSP stapling as recommended at
+  # https://community.letsencrypt.org/t/integration-guide/13123
+  # requires nginx version >= 1.3.7
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  add_header Strict-Transport-Security "max-age=31536000";
+  ssl_protocols TLSv1.1 TLSv1.2;
+  ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+  ssl_prefer_server_ciphers on;
+  ssl_dhparam /etc/dhparam/dhparams.pem;
+
+  access_log /var/log/nginx/dice.tripleawarclub.org-access.log;
+  error_log /var/log/nginx/dice.tripleawarclub.org-error.log;
+
+  index register.php;
+
+  location ~ \.php$ {
+    include snippets/fastcgi-php.conf;
+    include marti_prod_fastcgi_params;
+    fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+  }
+
+  location ~ \.(key|dat)$ {
+    deny all;
+  }
+}

--- a/config/nginx/dice.marti.triplea-game.org
+++ b/config/nginx/dice.marti.triplea-game.org
@@ -1,7 +1,3 @@
-# Session caching for improved performance
-
-ssl_session_cache shared:ssl_session_cache:10m;
-
 server {
   listen 80;
   listen [::]:80;
@@ -24,7 +20,6 @@ server {
   ssl_stapling on;
   ssl_stapling_verify on;
   add_header Strict-Transport-Security "max-age=31536000";
-  ssl_protocols TLSv1.1 TLSv1.2;
   ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
   ssl_prefer_server_ciphers on;
   ssl_dhparam /etc/dhparam/dhparams.pem;


### PR DESCRIPTION
I created new subdomains `dice.marti.triplea-game.org` and `dice-staging.marti.triplea-game.org` as a replacement for the respective `*.tripleawarclub.org` domains.  /cc @DanVanAtta 
This change is not really tested, nor ready to be applied, the required certificate doesn't really exist yet, also I'm not sure if this seems the best approach for this task.
The most notable change is that with this config HTTPS is finally being enforced.
As we need to change the config anyways, this shouldn't really be an issue.

Once this change is deployed, we simply update the config of the engine, and keep the old domain around until the domain expires.
First we need to generate a new HTTPS certificate though, however in order to generate it, we need to have a valid HTTP config first, so this is kinda a chicken and egg problem, not sure on how to approach it.
If someone has an idea on how to approach the problem, I'd be happy to give them a detailed introduction to the certbot tool and how it's currently being used.